### PR TITLE
fix: Update travis-ci to use uptrend-scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
   email: false
 install: yarn install
 script: yarn run validate
-after_success: kcd-scripts travis-after-success
-after_failure: echo installing codecov && npx -p codecov -c 'echo running codecov && codecov' 
+after_success: uptrend-scripts travis-after-success
+after_failure: echo installing codecov && npx -p codecov -c 'echo running codecov && codecov'
 branches:
   only: master


### PR DESCRIPTION
**What**: Fix travis-ci config to use `uptrend-scripts` in the `after_success` step
